### PR TITLE
GN-5 - Inital setup Rapier3d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.12.1"
+bevy_rapier3d = "0.23.0"

--- a/src/camera_system/camera_controls.rs
+++ b/src/camera_system/camera_controls.rs
@@ -42,7 +42,7 @@ fn zoom_camera(
         if let Ok(mut projection) = query.get_single_mut() {
             if let Projection::Orthographic(ref mut orthographic) = *projection {
                 orthographic.scale -= mouse_wheel.y * 0.1;
-                orthographic.scale = orthographic.scale.clamp(0.5, 10.);
+                orthographic.scale = orthographic.scale.clamp(1., 5.);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,12 @@ mod camera_system;
 
 use bevy::prelude::*;
 use bevy::render::camera::ScalingMode;
+use bevy_rapier3d::plugin::{NoUserData, RapierPhysicsPlugin};
 
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, camera_system::build_plugins()))
+        .add_plugins(RapierPhysicsPlugin::<NoUserData>::default())
         .add_systems(Startup, setup)
         .run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn setup(
     commands.spawn(Camera3dBundle {
         projection: OrthographicProjection {
             scale: 3.0,
-            scaling_mode: ScalingMode::FixedVertical(3.0),
+            scaling_mode: ScalingMode::FixedVertical(2.),
             ..default()
         }
         .into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 mod camera_system;
 
 use bevy::prelude::*;
+use bevy::prelude::*;
 use bevy::render::camera::ScalingMode;
-use bevy_rapier3d::plugin::{NoUserData, RapierPhysicsPlugin};
+use bevy_rapier3d::prelude::*;
 
 fn main() {
     App::new()
@@ -17,18 +18,29 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(32.0).into()),
-        material: materials.add(Color::WHITE.into()),
-        ..default()
-    });
+    // Create a static ground plane
+    commands
+        .spawn(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Plane::from_size(100.))),
+            material: materials.add(StandardMaterial {
+                base_color: Color::rgb(0.5, 0.5, 0.5),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .insert(Collider::cuboid(50.0, 0.1, 50.0));
+
     // cube
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb_u8(124, 144, 255).into()),
-        transform: Transform::from_xyz(0.0, 0.5, 0.0),
-        ..default()
-    });
+    commands
+        .spawn(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            material: materials.add(Color::rgb_u8(124, 144, 255).into()),
+            transform: Transform::from_xyz(0.0, 5., 0.0),
+            ..default()
+        })
+        .insert(RigidBody::Dynamic)
+        .insert(Collider::cuboid(0.5, 0.5, 0.5));
+
     // light
     commands.spawn(PointLightBundle {
         point_light: PointLight {


### PR DESCRIPTION
Fixes #5 

- Setup Rapier3d
- Extend cube and plane with colliders

![image](https://github.com/Napokue/gnoem/assets/6235760/cbe3e487-ac7d-4f74-bbb7-f21b3738bacb)
